### PR TITLE
feat: introduce code formatter and fix tabSize

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+   "ms-python.autopep8"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-    "python.pythonPath": "venv/bin/python3.7"
+  "python.pythonPath": "venv/bin/python3.7",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "editor.tabSize": 2,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8"
+  },
+  "autopep8.args": ["--indent-size=2", "--ignore=E121"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+autopep8==2.0.4
 datedelta==1.2
 python-dotenv==0.19.2
 pytz==2018.9

--- a/stripe-datev-cli.py
+++ b/stripe-datev-cli.py
@@ -1,21 +1,24 @@
-import decimal
-from functools import reduce
-import sys
 import argparse
+import decimal
+import os
+import os.path
+import sys
 from datetime import datetime, timedelta, timezone
+from functools import reduce
+
 import datedelta
-import stripe
-import stripe_datev.invoices, \
-  stripe_datev.charges, \
-  stripe_datev.customer, \
-  stripe_datev.payouts, \
-  stripe_datev.recognition, \
-  stripe_datev.output, \
-  stripe_datev.config, \
-  stripe_datev.transfers
-import os, os.path
-import requests
 import dotenv
+import requests
+import stripe
+
+import stripe_datev.charges
+import stripe_datev.config
+import stripe_datev.customer
+import stripe_datev.invoices
+import stripe_datev.output
+import stripe_datev.payouts
+import stripe_datev.recognition
+import stripe_datev.transfers
 
 dotenv.load_dotenv()
 
@@ -32,227 +35,257 @@ if stripe.api_key.startswith("sk_test"):
 if not os.path.exists(out_dir):
   os.mkdir(out_dir)
 
+
 class StripeDatevCli(object):
 
-    def run(self, argv):
-        parser = argparse.ArgumentParser(
-          description='Stripe utility',
-        )
-        parser.add_argument('command', type=str, help='Subcommand to run', choices=[
-          'download',
-          'validate_customers',
-          'fill_account_numbers',
-          'list_accounts',
-          'opos'
-        ])
+  def run(self, argv):
+    parser = argparse.ArgumentParser(
+      description='Stripe utility',
+    )
+    parser.add_argument('command', type=str, help='Subcommand to run', choices=[
+      'download',
+      'validate_customers',
+      'fill_account_numbers',
+      'list_accounts',
+      'opos'
+    ])
 
-        args = parser.parse_args(argv[1:2])
-        getattr(self, args.command)(argv[2:])
+    args = parser.parse_args(argv[1:2])
+    getattr(self, args.command)(argv[2:])
 
-    def download(self, argv):
-        parser = argparse.ArgumentParser(prog="stripe-datev-cli.py download")
-        parser.add_argument('year', type=int, help='year to download data for')
-        parser.add_argument('month', type=int, help='month to download data for')
+  def download(self, argv):
+    parser = argparse.ArgumentParser(prog="stripe-datev-cli.py download")
+    parser.add_argument('year', type=int, help='year to download data for')
+    parser.add_argument('month', type=int, help='month to download data for')
 
-        args = parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-        year = int(args.year)
-        month = int(args.month)
+    year = int(args.year)
+    month = int(args.month)
 
-        if month > 0:
-          fromTime = stripe_datev.config.accounting_tz.localize(datetime(year, month, 1, 0, 0, 0, 0))
-          toTime = fromTime + datedelta.MONTH
-        else:
-          fromTime = stripe_datev.config.accounting_tz.localize(datetime(year, 1, 1, 0, 0, 0, 0))
-          toTime = fromTime + datedelta.YEAR
-        print("Retrieving data between {} and {}".format(fromTime.strftime("%Y-%m-%d"), (toTime - timedelta(0, 1)).strftime("%Y-%m-%d")))
-        thisMonth = fromTime.astimezone(stripe_datev.config.accounting_tz).strftime("%Y-%m")
+    if month > 0:
+      fromTime = stripe_datev.config.accounting_tz.localize(
+        datetime(year, month, 1, 0, 0, 0, 0))
+      toTime = fromTime + datedelta.MONTH
+    else:
+      fromTime = stripe_datev.config.accounting_tz.localize(
+        datetime(year, 1, 1, 0, 0, 0, 0))
+      toTime = fromTime + datedelta.YEAR
+    print("Retrieving data between {} and {}".format(fromTime.strftime(
+      "%Y-%m-%d"), (toTime - timedelta(0, 1)).strftime("%Y-%m-%d")))
+    thisMonth = fromTime.astimezone(
+      stripe_datev.config.accounting_tz).strftime("%Y-%m")
 
-        invoices = list(reversed(list(stripe_datev.invoices.listFinalizedInvoices(fromTime, toTime))))
-        print("Retrieved {} invoice(s), total {} EUR".format(len(invoices), sum([decimal.Decimal(i.total) / 100 for i in invoices])))
+    invoices = list(
+      reversed(list(stripe_datev.invoices.listFinalizedInvoices(fromTime, toTime))))
+    print("Retrieved {} invoice(s), total {} EUR".format(
+      len(invoices), sum([decimal.Decimal(i.total) / 100 for i in invoices])))
 
-        revenue_items = stripe_datev.invoices.createRevenueItems(invoices)
+    revenue_items = stripe_datev.invoices.createRevenueItems(invoices)
 
-        charges = list(stripe_datev.charges.listChargesRaw(fromTime, toTime))
-        print("Retrieved {} charge(s), total {} EUR".format(len(charges), sum([decimal.Decimal(c.amount) / 100 for c in charges])))
+    charges = list(stripe_datev.charges.listChargesRaw(fromTime, toTime))
+    print("Retrieved {} charge(s), total {} EUR".format(
+      len(charges), sum([decimal.Decimal(c.amount) / 100 for c in charges])))
 
-        direct_charges = list(filter(lambda charge: not stripe_datev.charges.chargeHasInvoice(charge), charges))
-        revenue_items += stripe_datev.charges.createRevenueItems(direct_charges)
+    direct_charges = list(filter(
+      lambda charge: not stripe_datev.charges.chargeHasInvoice(charge), charges))
+    revenue_items += stripe_datev.charges.createRevenueItems(direct_charges)
 
-        overview_dir = os.path.join(out_dir, "overview")
-        if not os.path.exists(overview_dir):
-          os.mkdir(overview_dir)
+    overview_dir = os.path.join(out_dir, "overview")
+    if not os.path.exists(overview_dir):
+      os.mkdir(overview_dir)
 
-        with open(os.path.join(overview_dir, "overview-{:04d}-{:02d}.csv".format(year, month)), "w", encoding="utf-8") as fp:
-          fp.write(stripe_datev.invoices.to_csv(invoices))
-          print("Wrote {} invoices      to {}".format(str(len(invoices)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
+    with open(os.path.join(overview_dir, "overview-{:04d}-{:02d}.csv".format(year, month)), "w", encoding="utf-8") as fp:
+      fp.write(stripe_datev.invoices.to_csv(invoices))
+      print("Wrote {} invoices      to {}".format(
+        str(len(invoices)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
 
-        monthly_recognition_dir = os.path.join(out_dir, "monthly_recognition")
-        if not os.path.exists(monthly_recognition_dir):
-          os.mkdir(monthly_recognition_dir)
+    monthly_recognition_dir = os.path.join(out_dir, "monthly_recognition")
+    if not os.path.exists(monthly_recognition_dir):
+      os.mkdir(monthly_recognition_dir)
 
-        with open(os.path.join(monthly_recognition_dir, "monthly_recognition-{}.csv".format(thisMonth)), "w", encoding="utf-8") as fp:
-          fp.write(stripe_datev.invoices.to_recognized_month_csv2(revenue_items))
-          print("Wrote {} revenue items to {}".format(str(len(revenue_items)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
+    with open(os.path.join(monthly_recognition_dir, "monthly_recognition-{}.csv".format(thisMonth)), "w", encoding="utf-8") as fp:
+      fp.write(stripe_datev.invoices.to_recognized_month_csv2(revenue_items))
+      print("Wrote {} revenue items to {}".format(
+        str(len(revenue_items)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
 
-        datevDir = os.path.join(out_dir, 'datev')
-        if not os.path.exists(datevDir):
-          os.mkdir(datevDir)
+    datevDir = os.path.join(out_dir, 'datev')
+    if not os.path.exists(datevDir):
+      os.mkdir(datevDir)
 
-        # Datev Revenue
+    # Datev Revenue
 
-        records = []
-        for revenue_item in revenue_items:
-          records += stripe_datev.invoices.createAccountingRecords(revenue_item)
+    records = []
+    for revenue_item in revenue_items:
+      records += stripe_datev.invoices.createAccountingRecords(revenue_item)
 
-        records_by_month = {}
-        for record in records:
-          month = record["date"].strftime("%Y-%m")
-          records_by_month[month] = records_by_month.get(month, []) + [record]
+    records_by_month = {}
+    for record in records:
+      month = record["date"].strftime("%Y-%m")
+      records_by_month[month] = records_by_month.get(month, []) + [record]
 
-        for month, records in records_by_month.items():
-          if month == thisMonth:
-            name = "EXTF_{}_Revenue.csv".format(thisMonth)
-          else:
-            name = "EXTF_{}_Revenue_From_{}.csv".format(month, thisMonth)
-          stripe_datev.output.writeRecords(os.path.join(datevDir, name), records, bezeichung="Stripe Revenue {} from {}".format(month, thisMonth))
-
-        # Datev charges
-
-        charge_records = stripe_datev.charges.createAccountingRecords(charges)
-
-        charges_by_month = {}
-        for record in charge_records:
-          month = record["date"].strftime("%Y-%m")
-          charges_by_month[month] = charges_by_month.get(month, []) + [record]
-
-        for month, records in charges_by_month.items():
-          if month == thisMonth:
-            name = "EXTF_{}_Charges.csv".format(thisMonth)
-          else:
-            name = "EXTF_{}_Charges_From_{}.csv".format(month, thisMonth)
-          stripe_datev.output.writeRecords(os.path.join(datevDir, name), records, bezeichung="Stripe Charges/Fees {} from {}".format(month, thisMonth))
-
-        # Datev transfers
-
-        transfers = list(stripe_datev.transfers.listTransfersRaw(fromTime, toTime))
-        print("Retrieved {} transfer(s), total {} EUR".format(len(transfers), sum([decimal.Decimal(c.amount) / 100 for c in transfers])))
-
-        transfer_records = stripe_datev.transfers.createAccountingRecords(transfers)
-        stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Transfers.csv".format(thisMonth)), transfer_records, bezeichung="Stripe Transfers {}".format(thisMonth))
-
-        # Datev payouts
-
-        payoutObjects = list(stripe_datev.payouts.listPayouts(fromTime, toTime))
-        print("Retrieved {} payout(s), total {} EUR".format(len(payoutObjects), sum([r["amount"] for r in payoutObjects])))
-
-        payout_records = stripe_datev.payouts.createAccountingRecords(payoutObjects)
-        stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Payouts.csv".format(thisMonth)), payout_records, bezeichung="Stripe Payouts {}".format(thisMonth))
-
-        balance_transactions = list(stripe.BalanceTransaction.list(
-          created={
-            "lt": int(toTime.timestamp()),
-            "gte": int(fromTime.timestamp()),
-          },
-          type="contribution",
-        ).auto_paging_iter())
-        print("Retrieved {} contribution(s), total {} EUR".format(len(balance_transactions), sum([-decimal.Decimal(b["amount"]) / 100 for b in balance_transactions])))
-
-        contribution_records = stripe_datev.payouts.createAccountingRecordsContributions(balance_transactions)
-        stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Contributions.csv".format(thisMonth)), contribution_records, bezeichung="Stripe Contributions {}".format(thisMonth))
-
-        # PDF
-
-        pdfDir = os.path.join(out_dir, 'pdf')
-        if not os.path.exists(pdfDir):
-          os.mkdir(pdfDir)
-
-        for invoice in invoices:
-          pdfLink = invoice.invoice_pdf
-          finalized_date = datetime.fromtimestamp(invoice.status_transitions.finalized_at, timezone.utc).astimezone(stripe_datev.config.accounting_tz)
-          invNo = invoice.number
-
-          fileName = "{} {}.pdf".format(finalized_date.strftime("%Y-%m-%d"), invNo)
-          filePath = os.path.join(pdfDir, fileName)
-          if os.path.exists(filePath):
-            # print("{} exists, skipping".format(filePath))
-            continue
-
-          print("Downloading {} to {}".format(pdfLink, filePath))
-          r = requests.get(pdfLink)
-          if r.status_code != 200:
-            print("HTTP status {}".format(r.status_code))
-            continue
-          with open(filePath, "wb") as fp:
-            fp.write(r.content)
-
-        for charge in charges:
-          fileName = "{} {}.html".format(datetime.fromtimestamp(charge.created, timezone.utc).strftime("%Y-%m-%d"), charge.receipt_number or charge.id)
-          filePath = os.path.join(pdfDir, fileName)
-          if os.path.exists(filePath):
-            # print("{} exists, skipping".format(filePath))
-            continue
-
-          pdfLink = charge["receipt_url"]
-          print("Downloading {} to {}".format(pdfLink, filePath))
-          r = requests.get(pdfLink)
-          if r.status_code != 200:
-            print("HTTP status {}".format(r.status_code))
-            continue
-          with open(filePath, "wb") as fp:
-            fp.write(r.content)
-
-    def validate_customers(self, argv):
-      stripe_datev.customer.validate_customers()
-
-    def fill_account_numbers(self, argv):
-      stripe_datev.customer.fill_account_numbers()
-
-    def list_accounts(self, argv):
-      stripe_datev.customer.list_account_numbers(argv[0] if len(argv) > 0 else None)
-
-    def opos(self, argv):
-      if len(argv) > 0:
-        ref = datetime(*list(map(int, argv))) + timedelta(days=1) - timedelta(seconds=1)
-        status = None
+    for month, records in records_by_month.items():
+      if month == thisMonth:
+        name = "EXTF_{}_Revenue.csv".format(thisMonth)
       else:
-        ref = datetime.now()
-        status = "open"
+        name = "EXTF_{}_Revenue_From_{}.csv".format(month, thisMonth)
+      stripe_datev.output.writeRecords(os.path.join(
+        datevDir, name), records, bezeichung="Stripe Revenue {} from {}".format(month, thisMonth))
 
-      print("Unpaid invoices as of", stripe_datev.config.accounting_tz.localize(ref))
+    # Datev charges
 
-      invoices = stripe.Invoice.list(
-        created={
-          "lte": int(ref.timestamp()),
-          "gte": int((ref - datedelta.YEAR).timestamp()),
-        },
-        status=status,
-        expand=["data.customer"]
-      ).auto_paging_iter()
+    charge_records = stripe_datev.charges.createAccountingRecords(charges)
 
-      totals = []
-      for invoice in invoices:
-        finalized_at = invoice.status_transitions.get("finalized_at", None)
-        if finalized_at is None or datetime.utcfromtimestamp(finalized_at) > ref:
-          continue
-        marked_uncollectible_at = invoice.status_transitions.get("marked_uncollectible_at", None)
-        if marked_uncollectible_at is not None and datetime.utcfromtimestamp(marked_uncollectible_at) <= ref:
-          continue
-        voided_at = invoice.status_transitions.get("voided_at", None)
-        if voided_at is not None and datetime.utcfromtimestamp(voided_at) <= ref:
-          continue
-        paid_at = invoice.status_transitions.get("paid_at", None)
-        if paid_at is not None and datetime.utcfromtimestamp(paid_at) <= ref:
-          continue
+    charges_by_month = {}
+    for record in charge_records:
+      month = record["date"].strftime("%Y-%m")
+      charges_by_month[month] = charges_by_month.get(month, []) + [record]
 
-        customer = stripe_datev.customer.retrieveCustomer(invoice.customer)
-        due_date = datetime.utcfromtimestamp(invoice.due_date if invoice.due_date else invoice.created)
-        total = decimal.Decimal(invoice.total) / 100
-        totals.append(total)
-        print(invoice.number.ljust(13, " "), format(total, ",.2f").rjust(10, " "), "EUR", customer.email.ljust(35, " "), "due", due_date.date(), "({} overdue)".format(ref - due_date) if due_date < ref else "")
+    for month, records in charges_by_month.items():
+      if month == thisMonth:
+        name = "EXTF_{}_Charges.csv".format(thisMonth)
+      else:
+        name = "EXTF_{}_Charges_From_{}.csv".format(month, thisMonth)
+      stripe_datev.output.writeRecords(os.path.join(
+        datevDir, name), records, bezeichung="Stripe Charges/Fees {} from {}".format(month, thisMonth))
 
-      total = reduce(lambda x, y: x + y, totals, decimal.Decimal(0))
-      print("TOTAL        ", format(total, ",.2f").rjust(10, " "), "EUR")
+    # Datev transfers
+
+    transfers = list(stripe_datev.transfers.listTransfersRaw(fromTime, toTime))
+    print("Retrieved {} transfer(s), total {} EUR".format(
+      len(transfers), sum([decimal.Decimal(c.amount) / 100 for c in transfers])))
+
+    transfer_records = stripe_datev.transfers.createAccountingRecords(
+      transfers)
+    stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Transfers.csv".format(
+      thisMonth)), transfer_records, bezeichung="Stripe Transfers {}".format(thisMonth))
+
+    # Datev payouts
+
+    payoutObjects = list(stripe_datev.payouts.listPayouts(fromTime, toTime))
+    print("Retrieved {} payout(s), total {} EUR".format(
+      len(payoutObjects), sum([r["amount"] for r in payoutObjects])))
+
+    payout_records = stripe_datev.payouts.createAccountingRecords(
+      payoutObjects)
+    stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Payouts.csv".format(
+      thisMonth)), payout_records, bezeichung="Stripe Payouts {}".format(thisMonth))
+
+    balance_transactions = list(stripe.BalanceTransaction.list(
+      created={
+        "lt": int(toTime.timestamp()),
+        "gte": int(fromTime.timestamp()),
+      },
+      type="contribution",
+    ).auto_paging_iter())
+    print("Retrieved {} contribution(s), total {} EUR".format(len(balance_transactions), sum(
+      [-decimal.Decimal(b["amount"]) / 100 for b in balance_transactions])))
+
+    contribution_records = stripe_datev.payouts.createAccountingRecordsContributions(
+      balance_transactions)
+    stripe_datev.output.writeRecords(os.path.join(datevDir, "EXTF_{}_Contributions.csv".format(
+      thisMonth)), contribution_records, bezeichung="Stripe Contributions {}".format(thisMonth))
+
+    # PDF
+
+    pdfDir = os.path.join(out_dir, 'pdf')
+    if not os.path.exists(pdfDir):
+      os.mkdir(pdfDir)
+
+    for invoice in invoices:
+      pdfLink = invoice.invoice_pdf
+      finalized_date = datetime.fromtimestamp(
+        invoice.status_transitions.finalized_at, timezone.utc).astimezone(stripe_datev.config.accounting_tz)
+      invNo = invoice.number
+
+      fileName = "{} {}.pdf".format(finalized_date.strftime("%Y-%m-%d"), invNo)
+      filePath = os.path.join(pdfDir, fileName)
+      if os.path.exists(filePath):
+        # print("{} exists, skipping".format(filePath))
+        continue
+
+      print("Downloading {} to {}".format(pdfLink, filePath))
+      r = requests.get(pdfLink)
+      if r.status_code != 200:
+        print("HTTP status {}".format(r.status_code))
+        continue
+      with open(filePath, "wb") as fp:
+        fp.write(r.content)
+
+    for charge in charges:
+      fileName = "{} {}.html".format(datetime.fromtimestamp(
+        charge.created, timezone.utc).strftime("%Y-%m-%d"), charge.receipt_number or charge.id)
+      filePath = os.path.join(pdfDir, fileName)
+      if os.path.exists(filePath):
+        # print("{} exists, skipping".format(filePath))
+        continue
+
+      pdfLink = charge["receipt_url"]
+      print("Downloading {} to {}".format(pdfLink, filePath))
+      r = requests.get(pdfLink)
+      if r.status_code != 200:
+        print("HTTP status {}".format(r.status_code))
+        continue
+      with open(filePath, "wb") as fp:
+        fp.write(r.content)
+
+  def validate_customers(self, argv):
+    stripe_datev.customer.validate_customers()
+
+  def fill_account_numbers(self, argv):
+    stripe_datev.customer.fill_account_numbers()
+
+  def list_accounts(self, argv):
+    stripe_datev.customer.list_account_numbers(
+      argv[0] if len(argv) > 0 else None)
+
+  def opos(self, argv):
+    if len(argv) > 0:
+      ref = datetime(*list(map(int, argv))) + \
+          timedelta(days=1) - timedelta(seconds=1)
+      status = None
+    else:
+      ref = datetime.now()
+      status = "open"
+
+    print("Unpaid invoices as of", stripe_datev.config.accounting_tz.localize(ref))
+
+    invoices = stripe.Invoice.list(
+      created={
+        "lte": int(ref.timestamp()),
+        "gte": int((ref - datedelta.YEAR).timestamp()),
+      },
+      status=status,
+      expand=["data.customer"]
+    ).auto_paging_iter()
+
+    totals = []
+    for invoice in invoices:
+      finalized_at = invoice.status_transitions.get("finalized_at", None)
+      if finalized_at is None or datetime.utcfromtimestamp(finalized_at) > ref:
+        continue
+      marked_uncollectible_at = invoice.status_transitions.get(
+        "marked_uncollectible_at", None)
+      if marked_uncollectible_at is not None and datetime.utcfromtimestamp(marked_uncollectible_at) <= ref:
+        continue
+      voided_at = invoice.status_transitions.get("voided_at", None)
+      if voided_at is not None and datetime.utcfromtimestamp(voided_at) <= ref:
+        continue
+      paid_at = invoice.status_transitions.get("paid_at", None)
+      if paid_at is not None and datetime.utcfromtimestamp(paid_at) <= ref:
+        continue
+
+      customer = stripe_datev.customer.retrieveCustomer(invoice.customer)
+      due_date = datetime.utcfromtimestamp(
+        invoice.due_date if invoice.due_date else invoice.created)
+      total = decimal.Decimal(invoice.total) / 100
+      totals.append(total)
+      print(invoice.number.ljust(13, " "), format(total, ",.2f").rjust(10, " "), "EUR", customer.email.ljust(
+        35, " "), "due", due_date.date(), "({} overdue)".format(ref - due_date) if due_date < ref else "")
+
+    total = reduce(lambda x, y: x + y, totals, decimal.Decimal(0))
+    print("TOTAL        ", format(total, ",.2f").rjust(10, " "), "EUR")
+
 
 if __name__ == '__main__':
-    StripeDatevCli().run(sys.argv)
+  StripeDatevCli().run(sys.argv)

--- a/stripe_datev/charges.py
+++ b/stripe_datev/charges.py
@@ -1,7 +1,10 @@
-import stripe
 import decimal
 from datetime import datetime, timezone
-from . import customer, dateparser, output, config, invoices
+
+import stripe
+
+from . import config, customer, dateparser, invoices, output
+
 
 def listChargesRaw(fromTime, toTime):
   charges = stripe.Charge.list(
@@ -16,21 +19,26 @@ def listChargesRaw(fromTime, toTime):
       continue
     yield charge
 
+
 def chargeHasInvoice(charge):
   return charge.invoice is not None
 
+
 checkoutSessionsByPaymentIntent = {}
+
 
 def getCheckoutSessionViaPaymentIntentCached(id):
   if id in checkoutSessionsByPaymentIntent:
     return checkoutSessionsByPaymentIntent[id]
-  sessions = stripe.checkout.Session.list(payment_intent=id, expand=["data.line_items"]).data
+  sessions = stripe.checkout.Session.list(
+    payment_intent=id, expand=["data.line_items"]).data
   if len(sessions) > 0:
     session = sessions[0]
   else:
     session = None
   checkoutSessionsByPaymentIntent[id] = session
   return session
+
 
 def getChargeDescription(charge):
   if not charge.description and charge.payment_intent:
@@ -41,15 +49,18 @@ def getChargeDescription(charge):
       pass
   return charge.description
 
+
 def getChargeRecognitionRange(charge):
   desc = getChargeDescription(charge)
   created = datetime.fromtimestamp(charge.created, timezone.utc)
-  date_range = dateparser.find_date_range(desc, created, tz=config.accounting_tz)
+  date_range = dateparser.find_date_range(
+    desc, created, tz=config.accounting_tz)
   if date_range is not None:
     return date_range
   else:
     print("Warning: unknown period for charge --", charge.id, desc)
     return created, created
+
 
 def createRevenueItems(charges):
   revenue_items = []
@@ -59,15 +70,18 @@ def createRevenueItems(charges):
         print("Skipping fully refunded charge", charge.id)
         continue
       else:
-        raise NotImplementedError("Handling of partially refunded charges is not implemented yet")
+        raise NotImplementedError(
+          "Handling of partially refunded charges is not implemented yet")
     if "in_" in charge.description:
-      print("Skipping charge referencing invoice", charge.id, charge.description)
+      print("Skipping charge referencing invoice",
+            charge.id, charge.description)
       continue
 
     cus = customer.retrieveCustomer(charge.customer)
     session = getCheckoutSessionViaPaymentIntentCached(charge.payment_intent)
 
-    accounting_props = customer.getAccountingProps(cus, checkout_session=session)
+    accounting_props = customer.getAccountingProps(
+      cus, checkout_session=session)
     if charge.receipt_number:
       text = "Receipt {}".format(charge.receipt_number)
     else:
@@ -81,10 +95,12 @@ def createRevenueItems(charges):
     start, end = getChargeRecognitionRange(charge)
 
     charge_amount = decimal.Decimal(charge.amount) / 100
-    tax_amount = decimal.Decimal(session.total_details.amount_tax) / 100 if session else None
+    tax_amount = decimal.Decimal(
+      session.total_details.amount_tax) / 100 if session else None
     net_amount = charge_amount - tax_amount if tax_amount is not None else charge_amount
 
-    tax_percentage = None if tax_amount is None else decimal.Decimal(tax_amount) / decimal.Decimal(net_amount) * 100
+    tax_percentage = None if tax_amount is None else decimal.Decimal(
+      tax_amount) / decimal.Decimal(net_amount) * 100
 
     revenue_items.append({
       "id": charge.id,
@@ -107,17 +123,22 @@ def createRevenueItems(charges):
 
   return revenue_items
 
+
 def createAccountingRecords(charges):
   records = []
 
   for charge in charges:
-    acc_props = customer.getAccountingProps(customer.retrieveCustomer(charge.customer))
-    created = datetime.fromtimestamp(charge.created, timezone.utc).astimezone(config.accounting_tz)
+    acc_props = customer.getAccountingProps(
+      customer.retrieveCustomer(charge.customer))
+    created = datetime.fromtimestamp(
+      charge.created, timezone.utc).astimezone(config.accounting_tz)
 
-    balance_transaction = stripe.BalanceTransaction.retrieve(charge.balance_transaction)
+    balance_transaction = stripe.BalanceTransaction.retrieve(
+      charge.balance_transaction)
     assert len(balance_transaction.fee_details) == 1
     assert balance_transaction.fee_details[0].currency == "eur"
-    fee_amount = decimal.Decimal(balance_transaction.fee_details[0].amount) / 100
+    fee_amount = decimal.Decimal(
+      balance_transaction.fee_details[0].amount) / 100
     fee_desc = balance_transaction.fee_details[0].description
 
     if charge.invoice:
@@ -164,4 +185,3 @@ def createAccountingRecords(charges):
       })
 
   return records
-

--- a/stripe_datev/csv.py
+++ b/stripe_datev/csv.py
@@ -2,8 +2,10 @@
 def escape_csv_field(field_value, sep=","):
   if field_value is None:
     field_value = ""
-  field_value = field_value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ").replace(sep, ";")
+  field_value = field_value.replace("\r\n", " ").replace(
+    "\r", " ").replace("\n", " ").replace(sep, ";")
   return field_value
 
+
 def lines_to_csv(lines_rows, sep=",", nl="\n"):
-    return nl.join(map(lambda l: sep.join(map(lambda f: escape_csv_field(f, sep=sep), l)), lines_rows))
+  return nl.join(map(lambda l: sep.join(map(lambda f: escape_csv_field(f, sep=sep), l)), lines_rows))

--- a/stripe_datev/dateparser.py
+++ b/stripe_datev/dateparser.py
@@ -1,3 +1,5 @@
+import unittest
+import pytz
 import calendar
 import datetime
 import re
@@ -17,12 +19,17 @@ MONTHS = [
   ["Dec", "December"],
 ]
 
-def flatten(t):
-    return [item for sublist in t for item in sublist]
 
-YEAR_REGEX = re.compile("(?<=[\D^])(2019|2020|2021|2022|2023|2024|2025|2026)(?=\D|$)", re.M)
-MONTH_REGEX = re.compile("(?<=[\W^])({})(?=\W|$)".format("|".join(flatten(MONTHS))), re.M)
+def flatten(t):
+  return [item for sublist in t for item in sublist]
+
+
+YEAR_REGEX = re.compile(
+  "(?<=[\D^])(2019|2020|2021|2022|2023|2024|2025|2026)(?=\D|$)", re.M)
+MONTH_REGEX = re.compile(
+  "(?<=[\W^])({})(?=\W|$)".format("|".join(flatten(MONTHS))), re.M)
 DAY_REGEX = re.compile("(?<=[\D^])([0-9]{1,2})(?:st|nd|rd|th)(?=\W|$)", re.M)
+
 
 def find_date_range(text, ref_date=None, tz=None):
   years = [int(y) for y in YEAR_REGEX.findall(text)]
@@ -80,8 +87,7 @@ def find_date_range(text, ref_date=None, tz=None):
 
   return (start, end)
 
-import unittest
-import pytz
+
 class DateParserTestSuite(unittest.TestCase):
 
   ref_date = datetime.datetime(2021, 5, 10)
@@ -95,8 +101,10 @@ class DateParserTestSuite(unittest.TestCase):
     else:
       self.assertIsNotNone(start, "Did not expect start of range")
       self.assertIsNotNone(end, "Did not expect end of range")
-      self.assertEqual(r[0], self.tz.localize(start), "Start of range does not match: '{}'".format(strRange))
-      self.assertEqual(r[1], self.tz.localize(end), "End of range does not match: '{}'".format(strRange))
+      self.assertEqual(r[0], self.tz.localize(
+        start), "Start of range does not match: '{}'".format(strRange))
+      self.assertEqual(r[1], self.tz.localize(
+        end), "End of range does not match: '{}'".format(strRange))
 
   def test_parsing(self):
     self.assertStringRange(
@@ -106,12 +114,14 @@ class DateParserTestSuite(unittest.TestCase):
 
     self.assertStringRange(
       "Njord Analytics & Njord Player, RC44, valid Jan-Nov 2021",
-      datetime.datetime(2021, 1, 1), datetime.datetime(2021, 11, 30, 23, 59, 59)
+      datetime.datetime(2021, 1, 1), datetime.datetime(
+        2021, 11, 30, 23, 59, 59)
     )
 
     self.assertStringRange(
       "Njord Player & Fleet Race reports, per day, May 20th-23rd",
-      datetime.datetime(2021, 5, 20), datetime.datetime(2021, 5, 23, 23, 59, 59)
+      datetime.datetime(2021, 5, 20), datetime.datetime(
+        2021, 5, 23, 23, 59, 59)
     )
 
     self.assertStringRange(
@@ -121,12 +131,14 @@ class DateParserTestSuite(unittest.TestCase):
 
     self.assertStringRange(
       "Njord Analytics and Player; (ClubSwan 36); Tue Jun 22nd 2021",
-      datetime.datetime(2021, 6, 22), datetime.datetime(2021, 6, 22, 23, 59, 59)
+      datetime.datetime(2021, 6, 22), datetime.datetime(
+        2021, 6, 22, 23, 59, 59)
     )
 
     self.assertStringRange(
       "Njord Analytics & Njord Player; 2x Laser Radial; valid November 1st 2021 to December 31st 2024 (price per year)",
-      datetime.datetime(2021, 11, 1), datetime.datetime(2024, 12, 31, 23, 59, 59)
+      datetime.datetime(2021, 11, 1), datetime.datetime(
+        2024, 12, 31, 23, 59, 59)
     )
 
     self.assertStringRange(
@@ -143,6 +155,7 @@ class DateParserTestSuite(unittest.TestCase):
       "Njord Analytics & Njord Player, SailGP (8 boats), valid Jan 1st 2022 - Mar 31st 2022 (incl. loading all data from 2021/22 SailGP season)",
       datetime.datetime(2022, 1, 1), datetime.datetime(2022, 3, 31, 23, 59, 59)
     )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/stripe_datev/dateparser.py
+++ b/stripe_datev/dateparser.py
@@ -1,8 +1,9 @@
-import unittest
-import pytz
 import calendar
 import datetime
 import re
+import unittest
+
+import pytz
 
 MONTHS = [
   ["Jan", "January"],

--- a/stripe_datev/output.py
+++ b/stripe_datev/output.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-from . import config, customer
 import os
+from datetime import datetime
+
+from . import config, customer
 
 fields = [
   "Umsatz (ohne Soll/Haben-Kz)",
@@ -126,15 +127,20 @@ fields = [
   "",
 ]
 
+
 def filterRecords(records, fromTime=None, toTime=None):
   return list(filter(lambda r: (fromTime is None or r["date"] >= fromTime) and (toTime is None or r["date"] <= toTime), records))
+
 
 def writeRecords(fileName, records, fromTime=None, toTime=None, bezeichung=None):
   if len(records) == 0:
     return
   with open(fileName, 'w', encoding="latin1", errors="replace", newline="\r\n") as fp:
-    printRecords(fp, records, fromTime=fromTime, toTime=toTime, bezeichung=bezeichung)
-    print("Wrote {} acc. records  to {}".format(str(len(records)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
+    printRecords(fp, records, fromTime=fromTime,
+                 toTime=toTime, bezeichung=bezeichung)
+    print("Wrote {} acc. records  to {}".format(
+      str(len(records)).rjust(4, " "), os.path.relpath(fp.name, os.getcwd())))
+
 
 def printRecords(textFileHandle, records, fromTime=None, toTime=None, bezeichung=None):
   if fromTime is not None or toTime is not None:
@@ -142,32 +148,41 @@ def printRecords(textFileHandle, records, fromTime=None, toTime=None, bezeichung
 
   minTime = fromTime or min([r["date"] for r in records])
   maxTime = toTime or max([r["date"] for r in records])
-  years = set(r["date"].astimezone(config.accounting_tz).strftime("%Y") for r in records)
+  years = set(r["date"].astimezone(config.accounting_tz).strftime("%Y")
+              for r in records)
   if len(years) > 1:
-    raise Exception("May not print records from multiple years: {}".format(years))
+    raise Exception(
+      "May not print records from multiple years: {}".format(years))
 
   header = [
-    '"EXTF"', # DATEV-Format (DTVF - von DATEV erzeugt, EXTF Fremdprogramm)
-    '700', # Version des DATEV-Formats (141 bedeutet 1.41)
-    '21', # Datenkategorie (21 = Buchungsstapel, 67 = Buchungstextkonstanten, 16 = Debitoren/Kreditoren, 20 = Kontenbeschriftungen usw.)
-    'Buchungsstapel', # Formatname (Buchungsstapel, Buchungstextkonstanten, Debitoren/Kreditoren, Kontenbeschriftungen usw.)
-    '5', # Formatversion (bezogen auf Formatname)
-    datetime.today().astimezone(config.accounting_tz).strftime("%Y%m%d%H%M%S"), # '20190211202957107', # erzeugt am
-    '', # importiert am
-    'BH', # Herkunft
-    '', # exportiert von
-    '', # importiert von
-    str(config.berater_nr), # Beraternummer
-    str(config.mandenten_nr), # Mandantennummer
-    minTime.astimezone(config.accounting_tz).strftime('%Y') + '0101', # Wirtschaftsjahresbeginn
-    '4', # Sachkontenlänge
-    minTime.astimezone(config.accounting_tz).strftime('%Y%m%d'), # Datum Beginn Buchungsstapel
-    maxTime.astimezone(config.accounting_tz).strftime('%Y%m%d'), # Datum Ende Buchungsstapel
-    '"{}"'.format(bezeichung) if bezeichung else "", # Bezeichnung (Vorlaufname, z. B. Buchungsstapel)
-    '', # Diktatkürzel
-    '1', # Buchungstyp (bei Buchungsstapel = 1)
-    '0', # Rechnungslegungszweck
-    '0', # Festschreibung
+    '"EXTF"',  # DATEV-Format (DTVF - von DATEV erzeugt, EXTF Fremdprogramm)
+    '700',  # Version des DATEV-Formats (141 bedeutet 1.41)
+    # Datenkategorie (21 = Buchungsstapel, 67 = Buchungstextkonstanten, 16 = Debitoren/Kreditoren, 20 = Kontenbeschriftungen usw.)
+    '21',
+    # Formatname (Buchungsstapel, Buchungstextkonstanten, Debitoren/Kreditoren, Kontenbeschriftungen usw.)
+    'Buchungsstapel',
+    '5',  # Formatversion (bezogen auf Formatname)
+    datetime.today().astimezone(config.accounting_tz).strftime(
+      "%Y%m%d%H%M%S"),  # '20190211202957107', # erzeugt am
+    '',  # importiert am
+    'BH',  # Herkunft
+    '',  # exportiert von
+    '',  # importiert von
+    str(config.berater_nr),  # Beraternummer
+    str(config.mandenten_nr),  # Mandantennummer
+    minTime.astimezone(config.accounting_tz).strftime(
+      '%Y') + '0101',  # Wirtschaftsjahresbeginn
+    '4',  # Sachkontenlänge
+    minTime.astimezone(config.accounting_tz).strftime(
+      '%Y%m%d'),  # Datum Beginn Buchungsstapel
+    maxTime.astimezone(config.accounting_tz).strftime(
+      '%Y%m%d'),  # Datum Ende Buchungsstapel
+    # Bezeichnung (Vorlaufname, z. B. Buchungsstapel)
+    '"{}"'.format(bezeichung) if bezeichung else "",
+    '',  # Diktatkürzel
+    '1',  # Buchungstyp (bei Buchungsstapel = 1)
+    '0',  # Rechnungslegungszweck
+    '0',  # Festschreibung
     # 'EUR', # WKZ
   ]
   textFileHandle.write(";".join(header))
@@ -185,14 +200,18 @@ def printRecords(textFileHandle, records, fromTime=None, toTime=None, bezeichung
     textFileHandle.write(";".join(recordValues))
     textFileHandle.write("\n")
 
+
 def formatDateDatev(date):
   return date.astimezone(config.accounting_tz).strftime("%d%m")
+
 
 def formatDateHuman(date):
   return date.astimezone(config.accounting_tz).strftime("%d.%m.%Y")
 
+
 def formatDecimal(d):
   return "{0:.2f}".format(d).replace(",", "").replace(".", ",")
+
 
 fields_accounts = [
   "Konto",
@@ -201,7 +220,7 @@ fields_accounts = [
   "Name (Adressattyp natürl. Person)",
   "Vorname (Adressattyp natürl. Person)",
   "Name (Adressattyp keine Angabe)",
-  "Adressattyp", # 1 = natürl. Person 2 = Unternehmen
+  "Adressattyp",  # 1 = natürl. Person 2 = Unternehmen
   "Kurzbezeichnung",
   "EU-Land",
   "EU-UStID",
@@ -215,29 +234,34 @@ fields_accounts = [
   "E-Mail",
 ]
 
+
 def printAccounts(textFileHandle, customers):
   header = [
-    '"EXTF"', # DATEV-Format (DTVF - von DATEV erzeugt, EXTF Fremdprogramm)
-    '700', # Version des DATEV-Formats (141 bedeutet 1.41)
-    '16', # Datenkategorie (21 = Buchungsstapel, 67 = Buchungstextkonstanten, 16 = Debitoren/Kreditoren, 20 = Kontenbeschriftungen usw.)
-    'Debitoren/Kreditoren', # Formatname (Buchungsstapel, Buchungstextkonstanten, Debitoren/Kreditoren, Kontenbeschriftungen usw.)
-    '5', # Formatversion (bezogen auf Formatname)
-    datetime.today().astimezone(config.accounting_tz).strftime("%Y%m%d%H%M%S"), # '20190211202957107', # erzeugt am
-    '', # importiert am
-    'BH', # Herkunft
-    '', # exportiert von
-    '', # importiert von
-    str(config.berater_nr), # Beraternummer
-    str(config.mandenten_nr), # Mandantennummer
-    datetime.today().astimezone(config.accounting_tz).strftime('%Y') + '0101', # Wirtschaftsjahresbeginn
-    '4', # Sachkontenlänge
-    '', # Datum Beginn Buchungsstapel
-    '', # Datum Ende Buchungsstapel
-    '', # Bezeichnung (Vorlaufname, z. B. Buchungsstapel)
-    '', # Diktatkürzel
-    '0', # Buchungstyp (bei Buchungsstapel = 1)
-    '0', # Rechnungslegungszweck
-    '0', # Festschreibung
+    '"EXTF"',  # DATEV-Format (DTVF - von DATEV erzeugt, EXTF Fremdprogramm)
+    '700',  # Version des DATEV-Formats (141 bedeutet 1.41)
+    # Datenkategorie (21 = Buchungsstapel, 67 = Buchungstextkonstanten, 16 = Debitoren/Kreditoren, 20 = Kontenbeschriftungen usw.)
+    '16',
+    # Formatname (Buchungsstapel, Buchungstextkonstanten, Debitoren/Kreditoren, Kontenbeschriftungen usw.)
+    'Debitoren/Kreditoren',
+    '5',  # Formatversion (bezogen auf Formatname)
+    datetime.today().astimezone(config.accounting_tz).strftime(
+      "%Y%m%d%H%M%S"),  # '20190211202957107', # erzeugt am
+    '',  # importiert am
+    'BH',  # Herkunft
+    '',  # exportiert von
+    '',  # importiert von
+    str(config.berater_nr),  # Beraternummer
+    str(config.mandenten_nr),  # Mandantennummer
+    datetime.today().astimezone(config.accounting_tz).strftime(
+      '%Y') + '0101',  # Wirtschaftsjahresbeginn
+    '4',  # Sachkontenlänge
+    '',  # Datum Beginn Buchungsstapel
+    '',  # Datum Ende Buchungsstapel
+    '',  # Bezeichnung (Vorlaufname, z. B. Buchungsstapel)
+    '',  # Diktatkürzel
+    '0',  # Buchungstyp (bei Buchungsstapel = 1)
+    '0',  # Rechnungslegungszweck
+    '0',  # Festschreibung
     # 'EUR', # WKZ
   ]
   textFileHandle.write(";".join(header))

--- a/stripe_datev/payouts.py
+++ b/stripe_datev/payouts.py
@@ -1,7 +1,10 @@
-import stripe
 import decimal
 from datetime import datetime, timezone
+
+import stripe
+
 from . import output
+
 
 def listPayouts(fromTime, toTime):
   payouts = stripe.Payout.list(
@@ -27,10 +30,12 @@ def listPayouts(fromTime, toTime):
     }
     yield record
 
+
 def createAccountingRecords(payouts):
   records = []
   for payout in payouts:
-    text = "Stripe Payout {} / {}".format(payout["id"], payout["description"] or "")
+    text = "Stripe Payout {} / {}".format(
+      payout["id"], payout["description"] or "")
     record = {
       "date": payout["arrival_date"],
       "Umsatz (ohne Soll/Haben-Kz)": output.formatDecimal(payout["amount"]),
@@ -71,6 +76,7 @@ def createAccountingRecords(payouts):
     records.append(record)
   return records
 
+
 def createAccountingRecordsContributions(balance_transactions):
   records = []
   for balance_transaction in balance_transactions:
@@ -88,4 +94,3 @@ def createAccountingRecordsContributions(balance_transactions):
     }
     records.append(record)
   return records
-

--- a/stripe_datev/recognition.py
+++ b/stripe_datev/recognition.py
@@ -1,6 +1,8 @@
 import calendar
 import datetime
 import decimal
+import unittest
+
 
 def split_months(start, end, amounts):
   amounts = [decimal.Decimal(amount) for amount in amounts]
@@ -18,16 +20,20 @@ def split_months(start, end, amounts):
   months = []
   while current_month <= end:
     start_of_month = current_month.replace(day=1, hour=0, minute=0, second=0)
-    end_of_month = current_month.replace(day=calendar.monthrange(current_month.year, current_month.month)[1], hour=23, minute=59, second=59, tzinfo=None)
+    end_of_month = current_month.replace(day=calendar.monthrange(
+      current_month.year, current_month.month)[1], hour=23, minute=59, second=59, tzinfo=None)
     if start_of_month.tzinfo:
       end_of_month = start_of_month.tzinfo.localize(end_of_month)
 
-    month_duration = min(end, end_of_month) - max(start, start_of_month) + datetime.timedelta(seconds=1)
+    month_duration = min(end, end_of_month) - max(start,
+                                                  start_of_month) + datetime.timedelta(seconds=1)
     perc_of_total = decimal.Decimal.from_float(month_duration / total_duration)
 
-    month_amounts = [(amount * perc_of_total).quantize(decimal.Decimal(10) ** -2) for amount in amounts]
+    month_amounts = [
+      (amount * perc_of_total).quantize(decimal.Decimal(10) ** -2) for amount in amounts]
 
-    remaining_amounts = [remaining_amount - month_amounts[idx] for idx, remaining_amount in enumerate(remaining_amounts)]
+    remaining_amounts = [remaining_amount - month_amounts[idx]
+                         for idx, remaining_amount in enumerate(remaining_amounts)]
 
     months.append({
       "start": start_of_month,
@@ -37,7 +43,8 @@ def split_months(start, end, amounts):
 
     current_month = end_of_month + datetime.timedelta(seconds=1)
 
-  months[-1]["amounts"] = [month_amount + remaining_amounts[idx] for idx, month_amount in enumerate(months[-1]["amounts"])]
+  months[-1]["amounts"] = [month_amount + remaining_amounts[idx]
+                           for idx, month_amount in enumerate(months[-1]["amounts"])]
 
   if not any(amount != 0 for amount in months[-1]["amounts"]):
     months = months[:-1]
@@ -47,26 +54,40 @@ def split_months(start, end, amounts):
 
   return months
 
-import unittest
+
 class RecognitionTestSuite(unittest.TestCase):
   def test_split(self):
     self.assertEqual(
-      split_months(datetime.datetime(2021, 5, 1), datetime.datetime(2022, 4, 30), [decimal.Decimal(100)]),
+      split_months(datetime.datetime(2021, 5, 1), datetime.datetime(
+        2022, 4, 30), [decimal.Decimal(100)]),
       [
-        {'start': datetime.datetime(2021, 5, 1, 0, 0), 'end': datetime.datetime(2021, 5, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2021, 6, 1, 0, 0), 'end': datetime.datetime(2021, 6, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
-        {'start': datetime.datetime(2021, 7, 1, 0, 0), 'end': datetime.datetime(2021, 7, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2021, 8, 1, 0, 0), 'end': datetime.datetime(2021, 8, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2021, 9, 1, 0, 0), 'end': datetime.datetime(2021, 9, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
-        {'start': datetime.datetime(2021, 10, 1, 0, 0), 'end': datetime.datetime(2021, 10, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2021, 11, 1, 0, 0), 'end': datetime.datetime(2021, 11, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
-        {'start': datetime.datetime(2021, 12, 1, 0, 0), 'end': datetime.datetime(2021, 12, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2022, 1, 1, 0, 0), 'end': datetime.datetime(2022, 1, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2022, 2, 1, 0, 0), 'end': datetime.datetime(2022, 2, 28, 23, 59, 59), 'amounts': [decimal.Decimal('7.69')]},
-        {'start': datetime.datetime(2022, 3, 1, 0, 0), 'end': datetime.datetime(2022, 3, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
-        {'start': datetime.datetime(2022, 4, 1, 0, 0), 'end': datetime.datetime(2022, 4, 30, 23, 59, 59), 'amounts': [decimal.Decimal('7.95')]}
+        {'start': datetime.datetime(2021, 5, 1, 0, 0), 'end': datetime.datetime(
+          2021, 5, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2021, 6, 1, 0, 0), 'end': datetime.datetime(
+          2021, 6, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
+        {'start': datetime.datetime(2021, 7, 1, 0, 0), 'end': datetime.datetime(
+          2021, 7, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2021, 8, 1, 0, 0), 'end': datetime.datetime(
+          2021, 8, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2021, 9, 1, 0, 0), 'end': datetime.datetime(
+          2021, 9, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
+        {'start': datetime.datetime(2021, 10, 1, 0, 0), 'end': datetime.datetime(
+          2021, 10, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2021, 11, 1, 0, 0), 'end': datetime.datetime(
+          2021, 11, 30, 23, 59, 59), 'amounts': [decimal.Decimal('8.24')]},
+        {'start': datetime.datetime(2021, 12, 1, 0, 0), 'end': datetime.datetime(
+          2021, 12, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2022, 1, 1, 0, 0), 'end': datetime.datetime(
+          2022, 1, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2022, 2, 1, 0, 0), 'end': datetime.datetime(
+          2022, 2, 28, 23, 59, 59), 'amounts': [decimal.Decimal('7.69')]},
+        {'start': datetime.datetime(2022, 3, 1, 0, 0), 'end': datetime.datetime(
+          2022, 3, 31, 23, 59, 59), 'amounts': [decimal.Decimal('8.52')]},
+        {'start': datetime.datetime(2022, 4, 1, 0, 0), 'end': datetime.datetime(
+          2022, 4, 30, 23, 59, 59), 'amounts': [decimal.Decimal('7.95')]}
       ]
     )
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/stripe_datev/transfers.py
+++ b/stripe_datev/transfers.py
@@ -1,7 +1,10 @@
-import stripe
 import decimal
 from datetime import datetime, timezone
-from . import customer, dateparser, output, config, invoices
+
+import stripe
+
+from . import config, customer, dateparser, invoices, output
+
 
 def listTransfersRaw(fromTime, toTime):
   transfers = stripe.Transfer.list(
@@ -9,7 +12,8 @@ def listTransfersRaw(fromTime, toTime):
       "gte": int(fromTime.timestamp()),
       "lt": int(toTime.timestamp())
     },
-    expand=["data.destination", "data.source_transaction", "data.source_transaction.invoice"]
+    expand=["data.destination", "data.source_transaction",
+            "data.source_transaction.invoice"]
   ).auto_paging_iter()
   for transfer in transfers:
     if transfer.reversed:
@@ -21,9 +25,11 @@ def createAccountingRecords(transfers):
   records = []
 
   for transfer in transfers:
-    created = datetime.fromtimestamp(transfer.created, timezone.utc).astimezone(config.accounting_tz)
+    created = datetime.fromtimestamp(
+      transfer.created, timezone.utc).astimezone(config.accounting_tz)
 
-    net_amount = transfer.amount - (transfer.source_transaction.application_fee_amount or 0)
+    net_amount = transfer.amount - \
+        (transfer.source_transaction.application_fee_amount or 0)
 
     invoice = transfer.source_transaction.get("invoice", None)
     invoiceNumber = invoice.number if invoice else None
@@ -44,12 +50,10 @@ def createAccountingRecords(transfers):
       "Umsatz (ohne Soll/Haben-Kz)": output.formatDecimal(decimal.Decimal(net_amount) / 100),
       "Soll/Haben-Kennzeichen": "S",
       "WKZ Umsatz": "EUR",
-      "Konto":  transfer["destination"]["metadata"]["accountNumber"],
+      "Konto": transfer["destination"]["metadata"]["accountNumber"],
       "Gegenkonto (ohne BU-Schlüssel)": "1201",
       "Buchungstext": "Fremdleistung {} anteilig".format(invoiceNumber or transfer.id),
       "Belegfeld 1": transfer.id,
     })
 
   return records
-
-

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,18 +1,22 @@
-from stripe_datev import config, recognition
-import unittest
-import decimal
 import datetime
+import decimal
+import unittest
+
+from stripe_datev import config, recognition
+
 
 class RecognitionTest(unittest.TestCase):
 
-    def test_split_months_simple(self):
-        months = recognition.split_months(config.accounting_tz.localize(datetime.datetime(2020, 4, 1)), config.accounting_tz.localize(datetime.datetime(2020, 6, 30, 23, 59, 59)), [decimal.Decimal('100')])
+  def test_split_months_simple(self):
+    months = recognition.split_months(config.accounting_tz.localize(datetime.datetime(
+      2020, 4, 1)), config.accounting_tz.localize(datetime.datetime(2020, 6, 30, 23, 59, 59)), [decimal.Decimal('100')])
 
-        self.assertEqual(len(months), 3)
-        self.assertEqual(months[0]["amounts"], [decimal.Decimal('32.97')])
+    self.assertEqual(len(months), 3)
+    self.assertEqual(months[0]["amounts"], [decimal.Decimal('32.97')])
 
-    def test_split_months_negative(self):
-        months = recognition.split_months(datetime.datetime(2022, 11, 15, 17, 3, 22, tzinfo=config.accounting_tz), datetime.datetime(2023, 8, 16, 11, 52, 12, tzinfo=config.accounting_tz), [decimal.Decimal('-14.11')])
+  def test_split_months_negative(self):
+    months = recognition.split_months(datetime.datetime(2022, 11, 15, 17, 3, 22, tzinfo=config.accounting_tz), datetime.datetime(
+      2023, 8, 16, 11, 52, 12, tzinfo=config.accounting_tz), [decimal.Decimal('-14.11')])
 
-        self.assertEqual(len(months), 10)
-        self.assertEqual(months[-1]["amounts"], [decimal.Decimal('-0.78')])
+    self.assertEqual(len(months), 10)
+    self.assertEqual(months[-1]["amounts"], [decimal.Decimal('-0.78')])


### PR DESCRIPTION
- Introduced autopep8 as default formatter
- formatted all files with tab-size 2 and autopep8 rules (stripe-datev-cli.py was tab-size 4, all other files had 2)